### PR TITLE
feat: make `HeapBuilder` public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ bitflags = "2.4.1"
 encoding_rs = "0.8"
 indexmap = "2.0.2"
 num-bigint = "0.4.4"
-rand = "0.8.5"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0.49"
 wtf8 = "0.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::value::DenseArray;
 pub use crate::value::Error;
 pub use crate::value::ErrorName;
 pub use crate::value::Heap;
+pub use crate::value::HeapBuilder;
 pub use crate::value::HeapReference;
 pub use crate::value::HeapValue;
 pub use crate::value::Map;

--- a/src/value.rs
+++ b/src/value.rs
@@ -5,10 +5,13 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Write;
 use std::rc::Rc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use num_bigint::BigInt;
-use rand::Rng;
 use thiserror::Error;
+
+static NEXT_HEAP_ID: AtomicU64 = AtomicU64::new(1);
 
 struct HeapEqContext<'a, 'b, T> {
   heap: &'a Heap,
@@ -1097,14 +1100,14 @@ impl HeapEq for Error {
 }
 
 pub struct HeapBuilder {
-  heap_id: usize,
+  heap_id: u64,
   values: Vec<Option<HeapValue>>,
 }
 
 impl Default for HeapBuilder {
   fn default() -> Self {
     Self {
-      heap_id: rand::thread_rng().gen(),
+      heap_id: NEXT_HEAP_ID.fetch_add(1, Ordering::Relaxed),
       values: vec![],
     }
   }
@@ -1183,17 +1186,8 @@ impl HeapBuilder {
 }
 
 pub struct Heap {
-  heap_id: usize,
+  heap_id: u64,
   values: Vec<HeapValue>,
-}
-
-impl Default for Heap {
-  fn default() -> Self {
-    Self {
-      heap_id: rand::thread_rng().gen(),
-      values: vec![],
-    }
-  }
 }
 
 impl std::fmt::Debug for Heap {
@@ -1228,7 +1222,7 @@ impl Heap {
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HeapReference {
-  heap_id: usize,
+  heap_id: u64,
   index: usize,
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1190,6 +1190,12 @@ pub struct Heap {
   values: Vec<HeapValue>,
 }
 
+impl Default for Heap {
+  fn default() -> Self {
+    HeapBuilder::default().build().unwrap()
+  }
+}
+
 impl std::fmt::Debug for Heap {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "Heap ")?;

--- a/src/value.rs
+++ b/src/value.rs
@@ -1187,6 +1187,15 @@ pub struct Heap {
   values: Vec<HeapValue>,
 }
 
+impl Default for Heap {
+  fn default() -> Self {
+    Self {
+      heap_id: rand::thread_rng().gen(),
+      values: vec![],
+    }
+  }
+}
+
 impl std::fmt::Debug for Heap {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "Heap ")?;


### PR DESCRIPTION
Otherwise there is no way to use `ValueSerializer` without a previously deserialized value.